### PR TITLE
feat: port factory scripts to QRL v2 (qrl namespace, wallet.js v3), rebrand docs to QRC20

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-RPC_URL="http://127.0.0.1:8545" # replace your real rpc url
-MNEMONIC="your mnemonic here" # replace your real mnemonic
-CUSTOM_ERC20_FACTORY_ADDRESS="deployed custom ERC20 factory address" # you can get this address after done 1-deploy.js
-CUSTOM_ERC20_ADDRESS="deployed custom ERC20 address" # you can get this address after done 2-onchain-call.js
+RPC_URL="http://127.0.0.1:8545" # v2 testnet RPC, e.g. http://46.224.165.196:8545
+MNEMONIC="your mnemonic here" # 36-word Dilithium (MLDSA87) mnemonic for the funded deployer
+CUSTOM_ERC20_FACTORY_ADDRESS="deployed custom QRC20 factory address" # fill in after running 1-deploy.js (Q-prefixed)
+CUSTOM_ERC20_ADDRESS="deployed custom QRC20 token address" # fill in after running 2-onchain-call.js (Q-prefixed)
+HOLDER_ADDRESS="Q0000000000000000000000000000000000000000" # optional: address whose token balance 3-offchain-call.js should report

--- a/1-deploy.js
+++ b/1-deploy.js
@@ -16,9 +16,9 @@ if (!hexseed) {
     process.exit(1)
 }
 
-const acc = web3.zond.accounts.seedToAccount(hexseed)
-web3.zond.wallet?.add(hexseed)
-web3.zond.transactionConfirmationBlocks = config.tx_required_confirmations
+const acc = web3.qrl.accounts.seedToAccount(hexseed)
+web3.qrl.wallet?.add(hexseed)
+web3.qrl.transactionConfirmationBlocks = config.tx_required_confirmations
 
 const receiptHandler = function (receipt) {
     console.log("Contract address ", receipt.contractAddress)
@@ -30,20 +30,16 @@ const deployMyTokenContract = async () => {
     const output = contractCompiler.GetCompilerOutput()
 
     const contractABI = output.contracts['CustomERC20Factory.hyp']['CustomERC20Factory'].abi
-
-    // fs.writeFileSync("./CustomERC20FactoryABI.json", JSON.stringify(contractABI, null, 4), 'utf-8')
-    // throw new Error("custom");
-
     const contractByteCode = output.contracts['CustomERC20Factory.hyp']['CustomERC20Factory'].zvm.bytecode.object
-    const contract = new web3.zond.Contract(contractABI)
+    const contract = new web3.qrl.Contract(contractABI)
 
     const deployOptions = { data: contractByteCode, arguments: [] }
     const contractDeploy = contract.deploy(deployOptions)
     const estimatedGas = await contractDeploy.estimateGas({ from: acc.address })
-    const gasPrice = await web3.zond.getGasPrice()
+    const gasPrice = await web3.qrl.getGasPrice()
     const txObj = { type: '0x2', gas: estimatedGas, gasPrice: gasPrice, from: acc.address, data: contractDeploy.encodeABI() }
 
-    await web3.zond.sendTransaction(txObj, undefined, { checkRevertBeforeSending: false })
+    await web3.qrl.sendTransaction(txObj, undefined, { checkRevertBeforeSending: false })
         .on('confirmation', console.log)
         .on('receipt', receiptHandler)
         .on('error', console.error)

--- a/2-onchain-call.js
+++ b/2-onchain-call.js
@@ -62,9 +62,9 @@ const createCustomQRC20Token = async () => {
 
     const contract = new web3.qrl.Contract(contractABI, contractAddress)
 
-    const contractTransfer = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, owner, maxWalletAmount, maxTxLimit);
-    const estimatedGas = await contractTransfer.estimateGas({ "from": acc.address })
-    const txObj = { type: '0x2', gas: Number(estimatedGas) * 2, from: acc.address, data: contractTransfer.encodeABI(), to: contractAddress }
+    const createTokenMethod = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, owner, maxWalletAmount, maxTxLimit);
+    const estimatedGas = await createTokenMethod.estimateGas({ "from": acc.address })
+    const txObj = { type: '0x2', gas: Number(estimatedGas) * 2, from: acc.address, data: createTokenMethod.encodeABI(), to: contractAddress }
 
     await web3.qrl.sendTransaction(txObj, undefined, { checkRevertBeforeSending: true })
         .on('confirmation', handleConfirmation)

--- a/2-onchain-call.js
+++ b/2-onchain-call.js
@@ -17,9 +17,9 @@ if (!hexseed) {
     process.exit(1)
 }
 
-const acc = web3.zond.accounts.seedToAccount(hexseed)
-web3.zond.wallet?.add(hexseed)
-web3.zond.transactionConfirmationBlocks = config.tx_required_confirmations
+const acc = web3.qrl.accounts.seedToAccount(hexseed)
+web3.qrl.wallet?.add(hexseed)
+web3.qrl.transactionConfirmationBlocks = config.tx_required_confirmations
 
 const handleConfirmation = (data) => {
     fs.writeFileSync(
@@ -43,33 +43,33 @@ const handleReceipt = (data) => {
     );
 };
 
-const tokenName = "Zond Token"
-const tokenSymbol = "ZT"
+const tokenName = "QRL Token"
+const tokenSymbol = "QT"
 const initialSupply = "1000000000000000000000000000"
 const decimals = 18
 const maxSupply = "1000000000000000000000000000"
-const recipiet = "Z0000000000000000000000000000000000000000"
-const owner = "Z0000000000000000000000000000000000000000"
+const recipient = "Q0000000000000000000000000000000000000000"
+const owner = "Q0000000000000000000000000000000000000000"
 const maxWalletAmount = "100000000000000000000000"
 const maxTxLimit = "100000000000000000000000"
 
-const deployCustomERC20Token = async () => {
-    console.log('Attempting to call the contract transfer method from account:', acc.address)
+const createCustomQRC20Token = async () => {
+    console.log('Attempting to call the contract createToken method from account:', acc.address)
 
     let output = contractCompiler.GetCompilerOutput()
 
     const contractABI = output.contracts['CustomERC20Factory.hyp']['CustomERC20Factory'].abi
 
-    const contract = new web3.zond.Contract(contractABI, contractAddress)
+    const contract = new web3.qrl.Contract(contractABI, contractAddress)
 
-    const contractTransfer = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipiet, owner, maxWalletAmount, maxTxLimit);
+    const contractTransfer = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, owner, maxWalletAmount, maxTxLimit);
     const estimatedGas = await contractTransfer.estimateGas({ "from": acc.address })
     const txObj = { type: '0x2', gas: Number(estimatedGas) * 2, from: acc.address, data: contractTransfer.encodeABI(), to: contractAddress }
 
-    await web3.zond.sendTransaction(txObj, undefined, { checkRevertBeforeSending: true })
+    await web3.qrl.sendTransaction(txObj, undefined, { checkRevertBeforeSending: true })
         .on('confirmation', handleConfirmation)
         .on('receipt', handleReceipt)
         .on('error', console.error)
 }
 
-deployCustomERC20Token()
+createCustomQRC20Token()

--- a/3-offchain-call.js
+++ b/3-offchain-call.js
@@ -7,9 +7,9 @@ require('dotenv').config()
 const provider = process.env.RPC_URL
 const web3 = new Web3(new Web3.providers.HttpProvider(provider))
 
-const customERC20ADdress = process.env.CUSTOM_ERC20_ADDRESS;
+const customQRC20Address = process.env.CUSTOM_ERC20_ADDRESS;
 
-const accAddress = "Z2019EA08f4e24201B98f9154906Da4b924A04892"
+const accAddress = process.env.HOLDER_ADDRESS || "Q0000000000000000000000000000000000000000"
 
 const checkTokenInfo = async () => {
     console.log('Attempting to check Token info for account:', accAddress)
@@ -17,7 +17,7 @@ const checkTokenInfo = async () => {
     const output = contractCompiler.GetCompilerOutput()
     const contractABI = output.contracts['CustomERC20.hyp']['CustomERC20'].abi
 
-    const contract = new web3.zond.Contract(contractABI, customERC20ADdress)
+    const contract = new web3.qrl.Contract(contractABI, customQRC20Address)
     
     try {
         const name = await contract.methods.name().call()

--- a/README.md
+++ b/README.md
@@ -1,76 +1,84 @@
-# Custom ERC20 Factory Project
+# Custom QRC20 Factory Project
 
 ## Overview
 
-This project demonstrates the deployment and interaction with a custom ERC20 token factory on the Zond blockchain. The factory allows for the creation of ERC20 tokens with customizable parameters.
+This project demonstrates the deployment and interaction with a custom QRC20 token factory on the QRL v2 (post-quantum) blockchain. The factory allows for the creation of QRC20 tokens with customizable parameters (name, symbol, supply, decimals, max supply, max wallet amount, max tx limit, owner).
 
 ## Prerequisites
 
-- Node.js and npm
-- [nvm (Node Version Manager)](https://github.com/nvm-sh/nvm) for managing Node.js versions
-- Access to a Zond POS node
+- Node.js 22 (managed via [nvm](https://github.com/nvm-sh/nvm))
+- npm
+- Access to a QRL v2 JSON-RPC node (the node exposes the `qrl_*` RPC namespace)
+- A funded QRL Dilithium (MLDSA87) wallet — 36-word mnemonic
 
 ## Setup
 
-### Step 1: Install the Zond POS Node
+### Step 1: Obtain access to a QRL v2 node
 
-Follow the instructions here: [https://test-zond.theqrl.org/install](https://test-zond.theqrl.org/install)
+Either run your own QRL v2 node or use a public testnet RPC endpoint. See [https://test-zond.theqrl.org/install](https://test-zond.theqrl.org/install) for current node install instructions.
 
-### Step 2: Create a Zond Dilithium Wallet & Obtain Testnet QRL
+### Step 2: Create a QRL Dilithium wallet & obtain testnet QRL
 
-Use the [wallet creation instructions](https://test-zond.theqrl.org/creating-wallet) to create a wallet and note the Dilithium public address. Obtain testnet QRL via the [QRL Discord](https://www.theqrl.org/discord).
+Use the [wallet creation instructions](https://test-zond.theqrl.org/creating-wallet) to create a wallet and note the Q-prefixed Dilithium public address. Obtain testnet QRL via the [QRL Discord](https://www.theqrl.org/discord).
 
-### Step 3: Configure Environment Variables
+### Step 3: Configure environment variables
 
-Create a `.env` file in the root directory of the project. Use the `.env.example` as a template:
+Create a `.env` file in the root directory. Use `.env.example` as a template:
 
 ```
+RPC_URL=http://127.0.0.1:8545
 MNEMONIC=your_mnemonic_here
-RPC_URL=http://localhost:8545
-CUSTOM_ERC20_FACTORY_ADDRESS=your_contract_address_here
+CUSTOM_ERC20_FACTORY_ADDRESS=your_factory_contract_address_here
+CUSTOM_ERC20_ADDRESS=your_token_contract_address_here
 ```
 
-### Step 4: Update `config.json`
+> Env variable names are kept as `CUSTOM_ERC20_*` for backwards compatibility with downstream tooling; the deployed contracts are QRC20 tokens on QRL v2.
 
-Ensure `config.json` contains only the transaction confirmation settings:
+### Step 4: Confirm `config.json`
 
-```json:config.json
+```json
 {
     "tx_required_confirmations": 2
 }
 ```
 
-### Step 5: Install Dependencies
-
-Use nvm to set the correct Node.js version and install dependencies:
+### Step 5: Install dependencies
 
 ```bash
 nvm use 22
 npm install
 ```
 
-### Step 6: Deploy the Smart Contract
-
-Deploy the smart contract using the following command:
+### Step 6: Deploy the factory contract
 
 ```bash
 node 1-deploy.js
 ```
 
-After deployment, update the `CUSTOM_ERC20_FACTORY_ADDRESS` in your `.env` file with the contract address returned from the deployment.
+After deployment, update `CUSTOM_ERC20_FACTORY_ADDRESS` in your `.env` with the Q-prefixed contract address printed on receipt.
 
-### Step 7: Interact with the Smart Contract
-
-To interact with the deployed contract, run:
+### Step 7: Create a QRC20 token via the factory
 
 ```bash
 node 2-onchain-call.js
 ```
 
-## Further Steps
+This calls `createToken(...)` on the factory with the default parameters defined at the top of `2-onchain-call.js` (edit them as needed). The new token address is logged in the receipt.
 
-This project provides a basic setup for deploying and interacting with a custom ERC20 token factory. For more advanced usage and features, refer to the detailed documentation (in development).
+### Step 8: Read token info off-chain
+
+```bash
+node 3-offchain-call.js
+```
+
+Reads `name`, `symbol`, `decimals`, `totalSupply`, and the balance for `HOLDER_ADDRESS` on the token at `CUSTOM_ERC20_ADDRESS`.
+
+## v2 compatibility notes
+
+- Uses `@theqrl/web3 ^0.4.0` with the `qrl` namespace (`web3.qrl.*`) — legacy `web3.zond.*` calls will fail against a v2 node.
+- Seed derivation uses `@theqrl/wallet.js ^3.0.1` (`MLDSA87.newWalletFromMnemonic(...).getHexExtendedSeed()`).
+- All contract and account addresses on v2 are **Q-prefixed**.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/getcode.js
+++ b/getcode.js
@@ -4,18 +4,26 @@ require('dotenv').config()
 const provider = process.env.RPC_URL
 const web3 = new Web3(new Web3.providers.HttpProvider(provider))
 
-const contractAddress = "Z38cad9d0889643c271a718ba98c99b32a6a8331c"
+const contractAddress = process.env.CUSTOM_ERC20_FACTORY_ADDRESS || process.env.CUSTOM_ERC20_ADDRESS
 
 const getCode = async () => {
-    const code = await web3.zond.getCode(contractAddress, 'latest', function(result, error) {
-        if(error) {
-            console.log(error)
-        } else {
-            console.log(result)
-        }
-    });
+    if (!contractAddress) {
+        console.error("Set CUSTOM_ERC20_FACTORY_ADDRESS or CUSTOM_ERC20_ADDRESS in .env")
+        process.exit(1)
+    }
 
-    console.log(code)
+    try {
+        const code = await web3.qrl.getCode(contractAddress, 'latest')
+        if (!code || code === '0x' || code === '0x0') {
+            console.log(`No contract deployed at ${contractAddress}`)
+        } else {
+            console.log(`Contract at ${contractAddress} has bytecode (${code.length} chars):`)
+            console.log(code)
+        }
+    } catch (error) {
+        console.error("getCode failed:", error)
+        process.exit(1)
+    }
 }
 
 getCode()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,88 +1,31 @@
 {
-  "name": "zond-contract-example",
-  "version": "0.1.0",
-  "lockfileVersion": 2,
+  "name": "qrlv2-qrc20-factory",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zond-contract-example",
-      "version": "0.1.0",
+      "name": "qrlv2-qrc20-factory",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@theqrl/hypc": "^0.0.2",
-        "@theqrl/web3": "^0.3.0",
+        "@theqrl/wallet.js": "^3.0.1",
+        "@theqrl/web3": "^0.4.0",
         "dotenv": "^16.4.7"
       }
     },
-    "../web3.js/packages/@theqrl/web3": {
-      "extraneous": true
-    },
-    "../web3.js/packages/@theqrl/web3-zond": {
-      "extraneous": true
-    },
-    "../web3.js/packages/@theqrl/web3-zond-accounts": {
-      "extraneous": true
-    },
-    "../web3.js/packages/web3-eth": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-core-subscriptions": "1.7.5",
-        "web3-eth-abi": "1.7.5",
-        "web3-eth-accounts": "1.7.5",
-        "web3-eth-contract": "1.7.5",
-        "web3-eth-ens": "1.7.5",
-        "web3-eth-iban": "1.7.5",
-        "web3-eth-personal": "1.7.5",
-        "web3-net": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "../web3.js/packages/web3-eth-accounts": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
-        "scrypt-js": "^3.0.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
       "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -91,9 +34,9 @@
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
       "funding": [
         {
           "type": "individual",
@@ -104,20 +47,21 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
       "funding": [
         {
           "type": "individual",
@@ -128,18 +72,19 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
       "funding": [
         {
           "type": "individual",
@@ -150,18 +95,19 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
       "funding": [
         {
           "type": "individual",
@@ -172,14 +118,15 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
       "funding": [
         {
           "type": "individual",
@@ -190,9 +137,10 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
         "bn.js": "^5.2.1"
       }
     },
@@ -216,9 +164,9 @@
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
       "funding": [
         {
           "type": "individual",
@@ -229,14 +177,15 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0"
+        "@ethersproject/bignumber": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
       "funding": [
         {
           "type": "individual",
@@ -247,22 +196,23 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
       "funding": [
         {
           "type": "individual",
@@ -273,8 +223,9 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/bytes": "^5.8.0",
         "js-sha3": "0.8.0"
       }
     },
@@ -295,9 +246,9 @@
       "license": "MIT"
     },
     "node_modules/@ethersproject/networks": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
       "funding": [
         {
           "type": "individual",
@@ -308,8 +259,9 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/properties": {
@@ -332,9 +284,9 @@
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
       "funding": [
         {
           "type": "individual",
@@ -345,9 +297,10 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -375,9 +328,9 @@
       }
     },
     "node_modules/@ethersproject/strings": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
       "funding": [
         {
           "type": "individual",
@@ -388,16 +341,17 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
       "funding": [
         {
           "type": "individual",
@@ -408,22 +362,23 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0"
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
       "funding": [
         {
           "type": "individual",
@@ -434,31 +389,49 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
+      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@noble/hashes": "1.3.0"
       }
     },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -468,6 +441,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
       "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -476,6 +450,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
       "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.4.0",
         "@noble/hashes": "~1.4.0",
@@ -485,10 +460,35 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@scure/bip39": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
       "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
@@ -497,10 +497,23 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@theqrl/abi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.1.0.tgz",
-      "integrity": "sha512-QIJd8UreY+rjS3s2Tjrc6WaTpJV/Ro2k8OEh2OvhPckIiqS4nVPQVhVTahmI6jDi+Qq9b8jtrO+sFD5Snl0+cg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.4.0.tgz",
+      "integrity": "sha512-Or7z/3cshVyfZNgqXvkZ0YkOi7TBlkfQhUlcviSW7U9+MI1S8S0MhKj2TbS8JkZxjlr5aW7+4uNDGkaM0o91gA==",
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -511,22 +524,14 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "node_modules/@theqrl/dilithium5": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@theqrl/dilithium5/-/dilithium5-0.0.9.tgz",
-      "integrity": "sha512-GZAGr+XBLEcqNKnAMEDSJ7eubJv9Lbv9wfqZ1ELNo2ZFdaeqgeZDN7DxhT23bIyQ1/HWFssbJKHGJMaxFRYZRg==",
-      "dependencies": {
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
+        "@theqrl/web3-utils": "^0.4.0"
       }
     },
     "node_modules/@theqrl/hypc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@theqrl/hypc/-/hypc-0.0.2.tgz",
       "integrity": "sha512-XsP7hETJdlmmdGtmp/K5ZtTcz3EzZaP+WhjuOTf4PmhE+6oijN271H10htYHvBo95ED2OYiuUCYucYNw7Q6mfQ==",
+      "license": "MIT",
       "dependencies": {
         "command-exists": "^1.2.8",
         "commander": "^8.1.0",
@@ -540,36 +545,75 @@
         "hypcjs": "hypc.js"
       }
     },
-    "node_modules/@theqrl/wallet.js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-0.1.3.tgz",
-      "integrity": "sha512-MZLWszKmUlG4/unQ0xBPWKgJ6VvUkLycyEvDSrM67NLhejizqtauoEBrNJopfZrfssxUDm0L1K8Bqt7srfcCPA==",
+    "node_modules/@theqrl/mldsa87": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/mldsa87/-/mldsa87-2.0.1.tgz",
+      "integrity": "sha512-BPEvwrrphkMjyPnDorMzQdfrtICTZsiUxiBnwFkv2SfIcQwTTPQV3kTVfidZXXE7033ZCvhu1u5Aiw6TrjxPPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@theqrl/dilithium5": "^0.0.9",
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/qrl-cryptography/-/qrl-cryptography-0.1.1.tgz",
+      "integrity": "sha512-a81By7tsLiiTeVANrl7+0JXPBsOGhS78j+R4c1F3DOnbafliK34RHlezjVZnkGI9AoFkr3bUOfrkAtnETEOGgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.0.0",
+        "@noble/hashes": "~1.8.0",
+        "@theqrl/mldsa87": "2.0.1"
+      }
+    },
+    "node_modules/@theqrl/qrl-cryptography/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@theqrl/wallet.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-3.0.1.tgz",
+      "integrity": "sha512-2kDlvUQAoks6W/pYNcjXEBLXd3v+h0yN1kqx3oz21kBRXIwtDm2EhrMmIAOE44fvapDRmLfypfZipX1W2WIjKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
+      },
+      "engines": {
+        "node": ">=20.19"
       }
     },
     "node_modules/@theqrl/web3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.3.0.tgz",
-      "integrity": "sha512-SH13baAvggYh8ncJ49STFCgUTiNzVqyLjovUeYU+1zkmFzNVUgutC6l5A9tbzU/AooVhmpdZl+TG3GkRrmjoCw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.4.0.tgz",
+      "integrity": "sha512-ikpRzvJmctrkEr46V5E0etlUZBo4lhXoNFu3tS+3hjaNiExk+2IwKzSFtgL8/7k6JOZKcqjbFUUWiEBSfrtviw==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0",
-        "@theqrl/web3-zond-ens": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
+        "@theqrl/web3-core": "^0.4.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-net": "^0.4.0",
+        "@theqrl/web3-providers-http": "^0.4.0",
+        "@theqrl/web3-providers-ws": "^0.4.0",
+        "@theqrl/web3-qrl": "^0.4.0",
+        "@theqrl/web3-qrl-abi": "^0.4.0",
+        "@theqrl/web3-qrl-accounts": "^0.4.0",
+        "@theqrl/web3-qrl-contract": "^0.4.0",
+        "@theqrl/web3-qrl-iban": "^0.4.0",
+        "@theqrl/web3-qrl-qrns": "^0.4.0",
+        "@theqrl/web3-rpc-methods": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
       },
       "engines": {
         "node": ">=14.0.0",
@@ -577,32 +621,34 @@
       }
     },
     "node_modules/@theqrl/web3-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.3.0.tgz",
-      "integrity": "sha512-nwOUx1hXUjeyaFwUA1GkzudF7cfmyAv8F6HnartlVM8Y+Tdhqy+tLr/XV8XkmiMmIHC7qEkmuq2GtPKCGANqng==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.4.0.tgz",
+      "integrity": "sha512-djRYNVIfgCFF8B9hUZN3UaXQX1n+ZkyDLr2ysobtqHS6PdI83UuX1rWx+eFm+J5L/DkuXIsRXcUNF0WLUKbvpw==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-providers-http": "^0.4.0",
+        "@theqrl/web3-providers-ws": "^0.4.0",
+        "@theqrl/web3-qrl-iban": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6.12.0"
       },
       "optionalDependencies": {
-        "@theqrl/web3-providers-ipc": "^0.3.0"
+        "@theqrl/web3-providers-ipc": "^0.4.0"
       }
     },
     "node_modules/@theqrl/web3-errors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.3.0.tgz",
-      "integrity": "sha512-fZy77nXaubf+37ghegl36F4Ws1xRdyDXAPpgCaa1Y06M9hYwYyPvkrKGm+zo7OykvC7P/2EYtwSIjGlm+oSgnA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.4.0.tgz",
+      "integrity": "sha512-Fv198hEWtiDx+Cct7zWpkc6tyGOCTC0v2jxeqLvRq7TQgbJoCAJKrt9rNYfPyiLhBwRhK5hQqeKexKtwJBxKSw==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-types": "^0.3.0"
+        "@theqrl/web3-types": "^0.4.0"
       },
       "engines": {
         "node": ">=14",
@@ -610,14 +656,15 @@
       }
     },
     "node_modules/@theqrl/web3-net": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.3.0.tgz",
-      "integrity": "sha512-mdu+WosHOea3kc0oTPztGnx+Q0WubK6LWkAj6TMe5XptlqBDdc61SqieRHgF097hKntYz8EJeYMTka3X0I4+9A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.4.0.tgz",
+      "integrity": "sha512-fmcpPS1DgEHpTXoa0tr4xHQg1CFsT1x7o2nHP8TQE0ovPCRd0MAysSQGK+WJz7TrQidH4Kr8iGWQd0lVMlVgvg==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
+        "@theqrl/web3-core": "^0.4.0",
+        "@theqrl/web3-rpc-methods": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0"
       },
       "engines": {
         "node": ">=14",
@@ -625,13 +672,14 @@
       }
     },
     "node_modules/@theqrl/web3-providers-http": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.3.0.tgz",
-      "integrity": "sha512-PQAUO/SDaJQdge0wwI5ZvQlXAh3ZaqeF4/+ARTawDZhjxT64qGmz1/n8hH0M4Kn9a/VL4UC/0GBZSpZK1uGsKg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.4.0.tgz",
+      "integrity": "sha512-RhWbjhYgASQktEuKDNuavxP3iI8mH7WBRNpJiSABXl9d7LjFOJnKKu5rxMZw5doVUcFQiS7NTIzWe7Y/jgFpeg==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
         "cross-fetch": "^3.1.5"
       },
       "engines": {
@@ -640,14 +688,15 @@
       }
     },
     "node_modules/@theqrl/web3-providers-ipc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.3.0.tgz",
-      "integrity": "sha512-1QyX3DB18OennQ10wctvsabLJiHu8tQZG+LezqLm3v9+8yc6uSAlGmX1B4rXtb1VsvoF4klbq9iGYdVRVEmM2w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.4.0.tgz",
+      "integrity": "sha512-oVDyVQMFKMx6xX6nPFearqRQNb+72YCGQCNbtNZpGXxqlzpXG3m+ddOzPP7ECCEP2TKG3aVB88bbTr+dc4ejwA==",
+      "license": "LGPL-3.0",
       "optional": true,
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0"
       },
       "engines": {
         "node": ">=14",
@@ -655,13 +704,14 @@
       }
     },
     "node_modules/@theqrl/web3-providers-ws": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.3.0.tgz",
-      "integrity": "sha512-4y2hlnI3y0MA1v30x8n0naUK+zyMmNUL9ImNphGQIVxP2GotQEAaSJvJEkcNQccMAdGg/bS990l7vVf+gSQ5eQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.4.0.tgz",
+      "integrity": "sha512-m7F9YXVvO9ym35J47Rg/KXykbVdF7sH4tMSaNC5JvnXGUlA2kNzkg54AOhd2VY6p+SxJVy6aDu7zTf8lEbNpbw==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
         "@types/ws": "8.5.3",
         "isomorphic-ws": "^5.0.0",
         "ws": "^8.8.1"
@@ -671,76 +721,23 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@theqrl/web3-rpc-methods": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.3.0.tgz",
-      "integrity": "sha512-K4rWxYl0kauUgsb/nJqh2ra1W0DKYd2Yhwh8OLbDzVPWCLhX7DKliXt1zTUbNHy0fL/B6y3Qpu1OI4L9yb3KPQ==",
+    "node_modules/@theqrl/web3-qrl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl/-/web3-qrl-0.4.0.tgz",
+      "integrity": "sha512-Wt6NPm8MRfmUbhCF7Zyl3GCc33zBrxMCaNDBv33jYLPXgBLgsNrN3vtd983ObYLoqBXr29qKxunG9Hw9DOmmRQ==",
+      "license": "LGPL-3.0",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.3.0.tgz",
-      "integrity": "sha512-tiIxISN6vh6wzeT9FwrBzTn91BbQjFwuu2nJ3NIQTUKOermY7shiJ9cy/t4CFYIYrNqxj03tlHNpRqecAU4tbQ==",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.3.0.tgz",
-      "integrity": "sha512-b4J0nbufN981mz/5RVNGNzQinm1jRff2VCW4x8z1YxNffr52eCB7h0LD5/ua/fBVdy0QEv2eI7b2Eh4KmlGj4g==",
-      "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.3.0.tgz",
-      "integrity": "sha512-xX5Kywwi63wZY3YOj0CW7ysFKZxqXB9SciHfU+nezK4Z4lFSjiN6eawp+lciJnCT+qbpvoB3e+Z/x+5WRal79w==",
-      "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0",
-        "util": "^0.12.5",
-        "zod": "^3.21.4"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-zond": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond/-/web3-zond-0.3.0.tgz",
-      "integrity": "sha512-KOduhIfudlA1WXsBCaOLViD+WjaKRU/UaxysvthfdUN6NZgiwZsx//1zlwWDyxJS1c8TLmTBhl5qxKKhQMJ8AQ==",
-      "dependencies": {
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-core": "^0.4.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-net": "^0.4.0",
+        "@theqrl/web3-providers-ws": "^0.4.0",
+        "@theqrl/web3-qrl-abi": "^0.4.0",
+        "@theqrl/web3-qrl-accounts": "^0.4.0",
+        "@theqrl/web3-rpc-methods": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0",
         "setimmediate": "^1.0.5"
       },
       "engines": {
@@ -748,34 +745,20 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@theqrl/web3-zond-abi": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-abi/-/web3-zond-abi-0.3.0.tgz",
-      "integrity": "sha512-wnQXnFhcx/4zCeLt4vZA0g4phFIOvkEMMfmTwSXnNfhatSnCUtsW7cZ1UxCB6j87HGQ8FPeTee4D3SoVwj6z/A==",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "node_modules/@theqrl/web3-zond-accounts": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-accounts/-/web3-zond-accounts-0.3.0.tgz",
-      "integrity": "sha512-jkwFsqjDRafBjrnOsnX8FIjK9Xqp45FhSc4228Of+8hv74RG6CVkzG7XIWGhW24fvriK8ihXqcCg0yq6oUlwZA==",
+    "node_modules/@theqrl/web3-qrl-abi": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-abi/-/web3-qrl-abi-0.4.0.tgz",
+      "integrity": "sha512-wLrYYkmZmI/so7AH3IT6m37RXN6ZizYAoEFs/RHvjdTfgRTjyelnnVKuQ4a7c8h07EsYQ0F7apN0z9KMkTnzdA==",
+      "license": "LGPL-3.0",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.1",
-        "@theqrl/dilithium5": "^0.0.9",
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@theqrl/abi": "^0.4.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0",
         "crc-32": "^1.2.2",
         "ethereum-cryptography": "^2.0.0",
         "sha3": "^2.1.4"
@@ -785,53 +768,166 @@
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@theqrl/web3-zond-contract": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-contract/-/web3-zond-contract-0.3.0.tgz",
-      "integrity": "sha512-cPcFxRlQRyqotXiuLA7qYEKWLCJedM3tXtOB02qHuVR6aEDMyAAITvqAS6qzQG6zbitmtE5XfHJurQm4R3kGiQ==",
+    "node_modules/@theqrl/web3-qrl-abi/node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
       "dependencies": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0"
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-accounts": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-accounts/-/web3-qrl-accounts-0.4.0.tgz",
+      "integrity": "sha512-LwH4TWpE33lA7+iwQP45opKK1YWd/qpSfOX3GeCp3lOk/iRsy0AVgCeX2Q/Qtm+S6dt5xTIz1zVc4wA75gzLOQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "@theqrl/mldsa87": "^2.0.1",
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/wallet.js": "^2.0.2",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0",
+        "crc-32": "^1.2.2",
+        "sha3": "^2.1.4"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@theqrl/web3-zond-ens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-ens/-/web3-zond-ens-0.3.0.tgz",
-      "integrity": "sha512-W3qpm5jFwKfVm6qv01C0JIZXSicB2zjedUmMe8/Bz3AGo3zqTjY7SFsrj5D9m9M8JRTs8zUHxN6v2o8BzOsHLA==",
+    "node_modules/@theqrl/web3-qrl-accounts/node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-contract": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-contract/-/web3-qrl-contract-0.4.0.tgz",
+      "integrity": "sha512-EGh2s9vxBDTZEt/rvdFszXp2OQOn9cCg7Yx2uI6kBP7xPf4OO4sJiN8JLHtpBBKvQmIqJDJVhnOTwUrikPW6qw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/web3-core": "^0.4.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-qrl": "^0.4.0",
+        "@theqrl/web3-qrl-abi": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-iban": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-iban/-/web3-qrl-iban-0.4.0.tgz",
+      "integrity": "sha512-Waths6HKq3UzRGgSsbuz7mCfh0YfTeGAoqeulUh9qbLnBpF5CsWZ/v5WXMgy9l/R4S66Ro0IjxjfkWqLduIxRw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@theqrl/web3-qrl-qrns": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-qrl-qrns/-/web3-qrl-qrns-0.4.0.tgz",
+      "integrity": "sha512-zH6ktA+VxZok44xqe8uAdlts0MjgQw5J0fxFlCLvSU5lmlXq4JBQ5hOgGZILJCqyhyptmDx3fgfVlj943AUIkQ==",
+      "license": "LGPL-3.0",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0"
+        "@theqrl/web3-core": "^0.4.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-net": "^0.4.0",
+        "@theqrl/web3-qrl": "^0.4.0",
+        "@theqrl/web3-qrl-contract": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-utils": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@theqrl/web3-zond-iban": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-iban/-/web3-zond-iban-0.3.0.tgz",
-      "integrity": "sha512-mHCmFWPdu/i2I+eE+nAwh/eQvK7QYaF5INUzSQ3c0gh/G2ubViSVtxpL9QpzZ9Y0KyRLYZoALjopEpnGlshQhg==",
+    "node_modules/@theqrl/web3-qrl/node_modules/@theqrl/wallet.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-2.0.2.tgz",
+      "integrity": "sha512-gqmPE1D7qk2d6Qir0/iZeRGGr2eAVjps9Zql0P4pIw/uBjs81FBYio90c+RawkuKyc2WjlOLF6l3VI02z/rMSg==",
+      "license": "MIT",
       "dependencies": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
+        "@noble/hashes": "2.0.1",
+        "@theqrl/mldsa87": "2.0.1"
+      }
+    },
+    "node_modules/@theqrl/web3-rpc-methods": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.4.0.tgz",
+      "integrity": "sha512-wIlbv8bp67MmVY9RGu5TNsGPIgeWCQtlXCiPul7ht0uvx2i1Ivhxbs371N6tnQWNmMzJm90NWW5/IYsDUuh7RA==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/web3-core": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@theqrl/web3-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.4.0.tgz",
+      "integrity": "sha512-cqf82rY1DUWefIfBRQOnOiLfKld8CRdBW2A0lUXy+GpRMWZq/ubZyZ81F51g1sKNFLvPhgFYNVQ9bGAiuTzhxg==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@theqrl/web3-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.4.0.tgz",
+      "integrity": "sha512-E5j+xYUSiv2AexBIq4tp6VbqwfKlTY8i/a8QOwajvKWz+NWRggQgE2FSrQoVo05JWz8I0YzWc5+lFcAYBF3COg==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "@theqrl/web3-validator": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/@theqrl/web3-validator": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.4.0.tgz",
+      "integrity": "sha512-bAJLORT1gQz8hOoC9TS0K2MDvZ5lyYe0KaLIJHeZ2hbKEkYjHlXo8T/hUYPwZnlENhHYmjPMt46uaLaU8lyc0g==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@theqrl/qrl-cryptography": "^0.1.0",
+        "@theqrl/web3-errors": "^0.4.0",
+        "@theqrl/web3-types": "^0.4.0",
+        "util": "^0.12.5",
+        "zod": "^3.21.4"
       },
       "engines": {
         "node": ">=14",
@@ -839,17 +935,19 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
       "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -858,6 +956,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -885,7 +984,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
@@ -917,33 +1017,21 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
-      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -957,6 +1045,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -966,12 +1055,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -983,12 +1073,14 @@
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -997,6 +1089,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -1008,6 +1101,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
       "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -1016,6 +1110,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -1029,9 +1124,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1044,6 +1139,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1078,6 +1174,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1086,6 +1183,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1094,6 +1192,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1105,6 +1204,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
       "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.4.2",
         "@noble/hashes": "1.4.0",
@@ -1112,10 +1212,34 @@
         "@scure/bip39": "1.3.0"
       }
     },
+    "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -1136,6 +1260,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -1150,21 +1275,32 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -1181,6 +1317,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -1193,6 +1330,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1204,6 +1342,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -1215,6 +1354,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1226,6 +1366,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -1247,9 +1388,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -1285,17 +1427,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -1311,6 +1456,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -1319,12 +1465,14 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -1339,6 +1487,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -1356,6 +1505,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -1370,6 +1520,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
@@ -1377,12 +1528,14 @@
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1411,6 +1564,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1426,22 +1580,11 @@
         }
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1450,41 +1593,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -1510,6 +1628,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -1525,12 +1644,14 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sha3": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
       "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "6.0.3"
       }
@@ -1539,6 +1660,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -1549,31 +1671,20 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -1585,26 +1696,30 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
@@ -1616,9 +1731,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1636,1086 +1753,13 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
-    },
-    "web3.js/packages/@theqrl/web3": {
-      "extraneous": true
-    },
-    "web3.js/packages/@theqrl/web3-zond-accounts": {
-      "extraneous": true
-    },
-    "web3.js/packages/web3": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "web3-bzz": "1.7.5",
-        "web3-core": "1.7.5",
-        "web3-eth": "1.7.5",
-        "web3-eth-personal": "1.7.5",
-        "web3-net": "1.7.5",
-        "web3-shh": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "@types/node": "^12.12.6",
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5",
-        "web3-core-helpers": "1.7.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "web3.js/packages/web3-eth-accounts": {
-      "version": "1.7.5",
-      "extraneous": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
-        "scrypt-js": "^3.0.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.7.5",
-        "web3-core-helpers": "1.7.5",
-        "web3-core-method": "1.7.5",
-        "web3-utils": "1.7.5"
-      },
-      "devDependencies": {
-        "dtslint": "^3.4.1",
-        "typescript": "^3.9.5"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
-    },
-    "@ethereumjs/rlp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
-      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw=="
-    },
-    "@ethersproject/abstract-provider": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0"
-      }
-    },
-    "@ethersproject/abstract-signer": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
-      }
-    },
-    "@ethersproject/address": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0"
-      }
-    },
-    "@ethersproject/base64": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0"
-      }
-    },
-    "@ethersproject/bignumber": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "bn.js": "^5.2.1"
-      }
-    },
-    "@ethersproject/bytes": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
-      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
-      "requires": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "@ethersproject/constants": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0"
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@ethersproject/keccak256": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "@ethersproject/logger": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
-      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA=="
-    },
-    "@ethersproject/networks": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
-      "requires": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/properties": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
-      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
-      "requires": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "@ethersproject/rlp": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/signing-key": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
-      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
-      "requires": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.6.1",
-        "hash.js": "1.1.7"
-      }
-    },
-    "@ethersproject/strings": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/transactions": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
-      "requires": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0"
-      }
-    },
-    "@ethersproject/web": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
-      "requires": {
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "requires": {
-        "@noble/hashes": "1.4.0"
-      }
-    },
-    "@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
-    },
-    "@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
-    },
-    "@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "requires": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      }
-    },
-    "@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "requires": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      }
-    },
-    "@theqrl/abi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/abi/-/abi-0.1.0.tgz",
-      "integrity": "sha512-QIJd8UreY+rjS3s2Tjrc6WaTpJV/Ro2k8OEh2OvhPckIiqS4nVPQVhVTahmI6jDi+Qq9b8jtrO+sFD5Snl0+cg==",
-      "requires": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "@theqrl/dilithium5": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@theqrl/dilithium5/-/dilithium5-0.0.9.tgz",
-      "integrity": "sha512-GZAGr+XBLEcqNKnAMEDSJ7eubJv9Lbv9wfqZ1ELNo2ZFdaeqgeZDN7DxhT23bIyQ1/HWFssbJKHGJMaxFRYZRg==",
-      "requires": {
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
-      }
-    },
-    "@theqrl/hypc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@theqrl/hypc/-/hypc-0.0.2.tgz",
-      "integrity": "sha512-XsP7hETJdlmmdGtmp/K5ZtTcz3EzZaP+WhjuOTf4PmhE+6oijN271H10htYHvBo95ED2OYiuUCYucYNw7Q6mfQ==",
-      "requires": {
-        "command-exists": "^1.2.8",
-        "commander": "^8.1.0",
-        "follow-redirects": "^1.12.1",
-        "js-sha3": "0.8.0",
-        "memorystream": "^0.3.1",
-        "semver": "^5.5.0",
-        "tmp": "0.0.33"
-      }
-    },
-    "@theqrl/wallet.js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@theqrl/wallet.js/-/wallet.js-0.1.3.tgz",
-      "integrity": "sha512-MZLWszKmUlG4/unQ0xBPWKgJ6VvUkLycyEvDSrM67NLhejizqtauoEBrNJopfZrfssxUDm0L1K8Bqt7srfcCPA==",
-      "requires": {
-        "@theqrl/dilithium5": "^0.0.9",
-        "randombytes": "^2.1.0",
-        "sha3": "^2.1.4"
-      }
-    },
-    "@theqrl/web3": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3/-/web3-0.3.0.tgz",
-      "integrity": "sha512-SH13baAvggYh8ncJ49STFCgUTiNzVqyLjovUeYU+1zkmFzNVUgutC6l5A9tbzU/AooVhmpdZl+TG3GkRrmjoCw==",
-      "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0",
-        "@theqrl/web3-zond-ens": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-core/-/web3-core-0.3.0.tgz",
-      "integrity": "sha512-nwOUx1hXUjeyaFwUA1GkzudF7cfmyAv8F6HnartlVM8Y+Tdhqy+tLr/XV8XkmiMmIHC7qEkmuq2GtPKCGANqng==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-providers-http": "^0.3.0",
-        "@theqrl/web3-providers-ipc": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-iban": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-errors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-errors/-/web3-errors-0.3.0.tgz",
-      "integrity": "sha512-fZy77nXaubf+37ghegl36F4Ws1xRdyDXAPpgCaa1Y06M9hYwYyPvkrKGm+zo7OykvC7P/2EYtwSIjGlm+oSgnA==",
-      "requires": {
-        "@theqrl/web3-types": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-net": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-net/-/web3-net-0.3.0.tgz",
-      "integrity": "sha512-mdu+WosHOea3kc0oTPztGnx+Q0WubK6LWkAj6TMe5XptlqBDdc61SqieRHgF097hKntYz8EJeYMTka3X0I4+9A==",
-      "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-providers-http": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-http/-/web3-providers-http-0.3.0.tgz",
-      "integrity": "sha512-PQAUO/SDaJQdge0wwI5ZvQlXAh3ZaqeF4/+ARTawDZhjxT64qGmz1/n8hH0M4Kn9a/VL4UC/0GBZSpZK1uGsKg==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "cross-fetch": "^3.1.5"
-      }
-    },
-    "@theqrl/web3-providers-ipc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ipc/-/web3-providers-ipc-0.3.0.tgz",
-      "integrity": "sha512-1QyX3DB18OennQ10wctvsabLJiHu8tQZG+LezqLm3v9+8yc6uSAlGmX1B4rXtb1VsvoF4klbq9iGYdVRVEmM2w==",
-      "optional": true,
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-providers-ws": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-providers-ws/-/web3-providers-ws-0.3.0.tgz",
-      "integrity": "sha512-4y2hlnI3y0MA1v30x8n0naUK+zyMmNUL9ImNphGQIVxP2GotQEAaSJvJEkcNQccMAdGg/bS990l7vVf+gSQ5eQ==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@types/ws": "8.5.3",
-        "isomorphic-ws": "^5.0.0",
-        "ws": "^8.8.1"
-      }
-    },
-    "@theqrl/web3-rpc-methods": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-rpc-methods/-/web3-rpc-methods-0.3.0.tgz",
-      "integrity": "sha512-K4rWxYl0kauUgsb/nJqh2ra1W0DKYd2Yhwh8OLbDzVPWCLhX7DKliXt1zTUbNHy0fL/B6y3Qpu1OI4L9yb3KPQ==",
-      "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-types/-/web3-types-0.3.0.tgz",
-      "integrity": "sha512-tiIxISN6vh6wzeT9FwrBzTn91BbQjFwuu2nJ3NIQTUKOermY7shiJ9cy/t4CFYIYrNqxj03tlHNpRqecAU4tbQ=="
-    },
-    "@theqrl/web3-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-utils/-/web3-utils-0.3.0.tgz",
-      "integrity": "sha512-b4J0nbufN981mz/5RVNGNzQinm1jRff2VCW4x8z1YxNffr52eCB7h0LD5/ua/fBVdy0QEv2eI7b2Eh4KmlGj4g==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0"
-      }
-    },
-    "@theqrl/web3-validator": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-validator/-/web3-validator-0.3.0.tgz",
-      "integrity": "sha512-xX5Kywwi63wZY3YOj0CW7ysFKZxqXB9SciHfU+nezK4Z4lFSjiN6eawp+lciJnCT+qbpvoB3e+Z/x+5WRal79w==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "ethereum-cryptography": "^2.0.0",
-        "util": "^0.12.5",
-        "zod": "^3.21.4"
-      }
-    },
-    "@theqrl/web3-zond": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond/-/web3-zond-0.3.0.tgz",
-      "integrity": "sha512-KOduhIfudlA1WXsBCaOLViD+WjaKRU/UaxysvthfdUN6NZgiwZsx//1zlwWDyxJS1c8TLmTBhl5qxKKhQMJ8AQ==",
-      "requires": {
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-providers-ws": "^0.3.0",
-        "@theqrl/web3-rpc-methods": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0",
-        "@theqrl/web3-zond-accounts": "^0.3.0",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "@theqrl/web3-zond-abi": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-abi/-/web3-zond-abi-0.3.0.tgz",
-      "integrity": "sha512-wnQXnFhcx/4zCeLt4vZA0g4phFIOvkEMMfmTwSXnNfhatSnCUtsW7cZ1UxCB6j87HGQ8FPeTee4D3SoVwj6z/A==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@theqrl/abi": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-zond-accounts": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-accounts/-/web3-zond-accounts-0.3.0.tgz",
-      "integrity": "sha512-jkwFsqjDRafBjrnOsnX8FIjK9Xqp45FhSc4228Of+8hv74RG6CVkzG7XIWGhW24fvriK8ihXqcCg0yq6oUlwZA==",
-      "requires": {
-        "@ethereumjs/rlp": "^4.0.1",
-        "@theqrl/dilithium5": "^0.0.9",
-        "@theqrl/wallet.js": "^0.1.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "crc-32": "^1.2.2",
-        "ethereum-cryptography": "^2.0.0",
-        "sha3": "^2.1.4"
-      }
-    },
-    "@theqrl/web3-zond-contract": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-contract/-/web3-zond-contract-0.3.0.tgz",
-      "integrity": "sha512-cPcFxRlQRyqotXiuLA7qYEKWLCJedM3tXtOB02qHuVR6aEDMyAAITvqAS6qzQG6zbitmtE5XfHJurQm4R3kGiQ==",
-      "requires": {
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-abi": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-zond-ens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-ens/-/web3-zond-ens-0.3.0.tgz",
-      "integrity": "sha512-W3qpm5jFwKfVm6qv01C0JIZXSicB2zjedUmMe8/Bz3AGo3zqTjY7SFsrj5D9m9M8JRTs8zUHxN6v2o8BzOsHLA==",
-      "requires": {
-        "@adraffy/ens-normalize": "^1.8.8",
-        "@theqrl/web3-core": "^0.3.0",
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-net": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0",
-        "@theqrl/web3-zond": "^0.3.0",
-        "@theqrl/web3-zond-contract": "^0.3.0"
-      }
-    },
-    "@theqrl/web3-zond-iban": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@theqrl/web3-zond-iban/-/web3-zond-iban-0.3.0.tgz",
-      "integrity": "sha512-mHCmFWPdu/i2I+eE+nAwh/eQvK7QYaF5INUzSQ3c0gh/G2ubViSVtxpL9QpzZ9Y0KyRLYZoALjopEpnGlshQhg==",
-      "requires": {
-        "@theqrl/web3-errors": "^0.3.0",
-        "@theqrl/web3-types": "^0.3.0",
-        "@theqrl/web3-utils": "^0.3.0",
-        "@theqrl/web3-validator": "^0.3.0"
-      }
-    },
-    "@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
-      "requires": {
-        "undici-types": "~6.20.0"
-      }
-    },
-    "@types/ws": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
-      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "requires": {
-        "possible-typed-array-names": "^1.0.0"
-      }
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "bn.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "bufferutil": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
-      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
-    },
-    "call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      }
-    },
-    "call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "requires": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      }
-    },
-    "call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
-      }
-    },
-    "command-exists": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-    },
-    "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
-    },
-    "cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "requires": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "requires": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      }
-    },
-    "dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="
-    },
-    "dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      }
-    },
-    "elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.3",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-          "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
-        }
-      }
-    },
-    "es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-    },
-    "es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-    },
-    "es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "requires": {
-        "es-errors": "^1.3.0"
-      }
-    },
-    "ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "requires": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="
-    },
-    "for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "requires": {
-        "is-callable": "^1.2.7"
-      }
-    },
-    "function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
-    "get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      }
-    },
-    "get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "requires": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      }
-    },
-    "gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-    },
-    "has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "requires": {
-        "es-define-property": "^1.0.0"
-      }
-    },
-    "has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-    },
-    "has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "requires": {
-        "has-symbols": "^1.0.3"
-      }
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "requires": {
-        "function-bind": "^1.1.2"
-      }
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      }
-    },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-    },
-    "is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "requires": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      }
-    },
-    "is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      }
-    },
-    "is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "requires": {
-        "which-typed-array": "^1.1.16"
-      }
-    },
-    "isomorphic-ws": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "requires": {}
-    },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
-    "math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-    },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw=="
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
-    },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
-    "node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "optional": true,
-      "peer": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
-    },
-    "possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "requires": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      }
-    },
-    "semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-    },
-    "set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-    },
-    "sha3": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
-      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
-      "requires": {
-        "buffer": "6.0.3"
-      }
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
-    },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
-    },
-    "utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "node-gyp-build": "^4.3.0"
-      }
-    },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
-      "requires": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      }
-    },
-    "ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "requires": {}
-    },
-    "zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,21 @@
 {
-  "name": "zond-contract-example",
-  "version": "0.1.0",
-  "description": "",
-  "main": "index.js",
+  "name": "qrlv2-qrc20-factory",
+  "version": "0.2.0",
+  "description": "Custom QRC20 token factory for the QRL v2 (post-quantum) chain",
+  "main": "1-deploy.js",
   "scripts": {
+    "deploy": "node 1-deploy.js",
+    "create-token": "node 2-onchain-call.js",
+    "token-info": "node 3-offchain-call.js",
+    "getcode": "node getcode.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@theqrl/hypc": "^0.0.2",
-    "@theqrl/web3": "^0.3.0",
+    "@theqrl/wallet.js": "^3.0.1",
+    "@theqrl/web3": "^0.4.0",
     "dotenv": "^16.4.7"
   }
 }

--- a/utils/getHexSeedFromMnemonic.js
+++ b/utils/getHexSeedFromMnemonic.js
@@ -1,15 +1,14 @@
-const { MnemonicToSeedBin } = require("@theqrl/wallet.js");
-const { Buffer } = require("buffer");
-require("dotenv").config()
+const { MLDSA87 } = require("@theqrl/wallet.js");
+require("dotenv").config();
 
 const getHexSeedFromMnemonic = (mnemonic) => {
   if (!mnemonic) return "";
   const trimmedMnemonic = mnemonic.trim();
   if (!trimmedMnemonic) return "";
-  const seedBin = MnemonicToSeedBin(trimmedMnemonic);
-  return "0x".concat(Buffer.from(seedBin).toString("hex"));
+  const wallet = MLDSA87.newWalletFromMnemonic(trimmedMnemonic);
+  return wallet.getHexExtendedSeed();
 };
 
 module.exports = {
   getHexSeedFromMnemonic,
-}
+};


### PR DESCRIPTION
## Summary

Ports every deploy/call script to the **v2 QRL chain**, which exposes the `qrl_*` JSON-RPC namespace only (not legacy `zond_*`). The previous scripts fail on v2 testnet with `the method zond_* does not exist/is not available`. Also rebrands the README from *ERC20* → *QRC20* and from *Zond blockchain* → *QRL v2 (post-quantum) blockchain* so the docs reflect what the repo actually ships on.

- Bump `@theqrl/web3` to `^0.4.0` (v2 stack, `web3.qrl`) and add `@theqrl/wallet.js ^3.0.1`.
- Rewrite `utils/getHexSeedFromMnemonic.js` to the v2 `MLDSA87.newWalletFromMnemonic(...).getHexExtendedSeed()` API (same pattern as `myqrlwallet-frontend/src/utils/crypto/mnemonic.ts`).
- Translate `web3.zond.*` → `web3.qrl.*` in `1-deploy.js`, `2-onchain-call.js`, `3-offchain-call.js`, `getcode.js`.
- Replace Z-prefixed zero/example addresses with Q-prefixed equivalents. `3-offchain-call.js` now reads the holder from `HOLDER_ADDRESS`; `getcode.js` reads the contract from `CUSTOM_ERC20_FACTORY_ADDRESS` / `CUSTOM_ERC20_ADDRESS`.
- README rewritten for QRC20 + v2 terminology, with a new *v2 compatibility notes* section. Env variable names (`CUSTOM_ERC20_*`) left unchanged for downstream-tooling compatibility — noted in README.
- `.env.example` updated: v2 testnet RPC hint, 36-word MLDSA87 mnemonic note, optional `HOLDER_ADDRESS`.
- `package-lock.json` regenerated against the new dep set.

Contract source (`contracts/*.hyp`) is untouched — this PR is purely the JS compat layer + documentation rebrand.

## Verification

Live-deployed the ported `1-deploy.js` on the QRL v2 testnet node (`46.224.165.196:8545`, chain id 1337):

| Item | Value |
|---|---|
| Deployer | `Q79b662Ce3d663643dF4454A8Ba3f532C0DE6887f` |
| Factory | `Q42d476d77e6555c1b5b8c8d213f5ef47ef6e7107` |
| Tx hash | `0x3421c509512f2ca58aac6973eb75d4f57daaedbb6d36e74ab4ee9f0c128ae9bf` |
| Block | 30713 |
| Gas used | 2,540,870 |
| Status | 1 |

`web3.qrl.getCode(factory)` returns 23,144 chars of bytecode on the v2 RPC.

Downstream: `myqrlwallet-frontend` prod + dev `.env`s have been updated with the new Q-prefixed factory + deployer, both rebuilt, and both `qrlwallet.com` and `dev.qrlwallet.com` now serve bundles with the new factory address inlined.

## Test plan

- [ ] `nvm use 22 && npm ci` resolves the new dep tree cleanly
- [ ] `node getcode.js` against v2 RPC returns bytecode for the deployed factory
- [ ] `node 2-onchain-call.js` against the deployed factory successfully creates a QRC20 token (populate `CUSTOM_ERC20_FACTORY_ADDRESS` in `.env` first)
- [ ] `node 3-offchain-call.js` against the created token prints name/symbol/decimals/totalSupply/balance
- [ ] `myqrlwallet-frontend` CreateToken flow against `dev.qrlwallet.com` successfully creates a token on v2 testnet