### PR TITLE
feat: harden factory contracts per security audit (H-1, H-2, M-1, M-4)

### DIFF
--- a/2-onchain-call.js
+++ b/2-onchain-call.js
@@ -49,7 +49,6 @@ const initialSupply = "1000000000000000000000000000"
 const decimals = 18
 const maxSupply = "1000000000000000000000000000"
 const recipient = "Q0000000000000000000000000000000000000000"
-const owner = "Q0000000000000000000000000000000000000000"
 const maxWalletAmount = "100000000000000000000000"
 const maxTxLimit = "100000000000000000000000"
 
@@ -62,7 +61,7 @@ const createCustomQRC20Token = async () => {
 
     const contract = new web3.qrl.Contract(contractABI, contractAddress)
 
-    const createTokenMethod = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, owner, maxWalletAmount, maxTxLimit);
+    const createTokenMethod = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, maxWalletAmount, maxTxLimit);
     const estimatedGas = await createTokenMethod.estimateGas({ from: acc.address })
     const gas = (estimatedGas * 12n) / 10n
     const gasPrice = await web3.qrl.getGasPrice()

--- a/contracts/CustomERC20.hyp
+++ b/contracts/CustomERC20.hyp
@@ -4,6 +4,12 @@ pragma hyperion ^0.0.2;
 import "./ERC20.hyp";
 import "./Ownable.hyp";
 
+/**
+ * @title CustomERC20
+ * @notice QRC20 token with configurable supply cap, per-wallet cap, and per-tx cap.
+ *         The owner can mint up to `maxSupply`, adjust caps, and manage the
+ *         cap-bypass whitelist post-deploy. `maxSupply` is immutable.
+ */
 contract CustomERC20 is ERC20, Ownable {
     uint8 private immutable _decimals;
     uint256 public immutable maxSupply;
@@ -11,6 +17,10 @@ contract CustomERC20 is ERC20, Ownable {
     uint256 public maxTxLimit;
 
     mapping(address => bool) private _isExcludedFromLimits;
+
+    event MaxWalletAmountUpdated(uint256 previousValue, uint256 newValue);
+    event MaxTxLimitUpdated(uint256 previousValue, uint256 newValue);
+    event ExcludedFromLimitsUpdated(address indexed account, bool excluded);
 
     constructor(
         string memory name_,
@@ -23,21 +33,91 @@ contract CustomERC20 is ERC20, Ownable {
         uint256 maxWalletAmount_,
         uint256 maxTxLimit_
     ) ERC20(name_, symbol_) Ownable() {
+        require(decimals_ <= 18, "CustomERC20: decimals > 18");
+        require(maxSupply_ > 0, "CustomERC20: maxSupply is zero");
+        require(initialSupply_ <= maxSupply_, "CustomERC20: initialSupply exceeds maxSupply");
+        require(owner_ != address(0), "CustomERC20: owner is zero");
+        require(recipient_ != address(0), "CustomERC20: recipient is zero");
+
         _decimals = decimals_;
-        maxSupply = maxSupply_ > 0 ? maxSupply_ : type(uint256).max; // Default to unlimited if not set
+        maxSupply = maxSupply_;
         maxWalletAmount = maxWalletAmount_;
         maxTxLimit = maxTxLimit_;
 
         _mint(recipient_, initialSupply_);
 
         _isExcludedFromLimits[recipient_] = true;
-        _isExcludedFromLimits[owner_] = true;
+        emit ExcludedFromLimitsUpdated(recipient_, true);
 
+        // transferOwnership will move exclusion from the deploying contract
+        // (factory / EOA) to owner_ via the _transferOwnership override.
         transferOwnership(owner_);
     }
 
     function decimals() public view override returns (uint8) {
         return _decimals;
+    }
+
+    /**
+     * @notice Mint `amount` new tokens to `to`. Only callable by the owner.
+     *         Reverts if `totalSupply() + amount > maxSupply`.
+     */
+    function mint(address to, uint256 amount) external onlyOwner {
+        require(totalSupply() + amount <= maxSupply, "CustomERC20: exceeds maxSupply");
+        _mint(to, amount);
+    }
+
+    /**
+     * @notice Set the per-wallet holding cap. Zero disables the cap.
+     */
+    function setMaxWalletAmount(uint256 newValue) external onlyOwner {
+        emit MaxWalletAmountUpdated(maxWalletAmount, newValue);
+        maxWalletAmount = newValue;
+    }
+
+    /**
+     * @notice Set the per-tx transfer cap. Zero disables the cap.
+     */
+    function setMaxTxLimit(uint256 newValue) external onlyOwner {
+        emit MaxTxLimitUpdated(maxTxLimit, newValue);
+        maxTxLimit = newValue;
+    }
+
+    /**
+     * @notice Add or remove `account` from the cap-bypass whitelist.
+     *         Whitelisted accounts bypass both maxWalletAmount and maxTxLimit
+     *         on both the sender and recipient side.
+     */
+    function setExcludedFromLimits(address account, bool excluded) external onlyOwner {
+        _isExcludedFromLimits[account] = excluded;
+        emit ExcludedFromLimitsUpdated(account, excluded);
+    }
+
+    /**
+     * @notice Returns true if `account` is exempt from per-wallet / per-tx caps.
+     */
+    function isExcludedFromLimits(address account) external view returns (bool) {
+        return _isExcludedFromLimits[account];
+    }
+
+    /**
+     * @dev Keeps the cap-bypass whitelist aligned with the owner role across
+     *      ownership handoffs. Renouncing ownership (newOwner == address(0))
+     *      still revokes the old owner's exemption; a follow-up
+     *      setExcludedFromLimits(oldOwner, true) by the new owner can restore
+     *      it if desired.
+     */
+    function _transferOwnership(address newOwner) internal override {
+        address oldOwner = owner();
+        if (oldOwner != address(0) && oldOwner != newOwner) {
+            _isExcludedFromLimits[oldOwner] = false;
+            emit ExcludedFromLimitsUpdated(oldOwner, false);
+        }
+        if (newOwner != address(0) && !_isExcludedFromLimits[newOwner]) {
+            _isExcludedFromLimits[newOwner] = true;
+            emit ExcludedFromLimitsUpdated(newOwner, true);
+        }
+        super._transferOwnership(newOwner);
     }
 
     function transfer(address recipient, uint256 amount) public override returns (bool) {

--- a/contracts/CustomERC20.hyp
+++ b/contracts/CustomERC20.hyp
@@ -33,6 +33,8 @@ contract CustomERC20 is ERC20, Ownable {
         uint256 maxWalletAmount_,
         uint256 maxTxLimit_
     ) ERC20(name_, symbol_) Ownable() {
+        require(bytes(name_).length > 0, "CustomERC20: empty name");
+        require(bytes(symbol_).length > 0, "CustomERC20: empty symbol");
         require(decimals_ <= 18, "CustomERC20: decimals > 18");
         require(maxSupply_ > 0, "CustomERC20: maxSupply is zero");
         require(initialSupply_ <= maxSupply_, "CustomERC20: initialSupply exceeds maxSupply");

--- a/contracts/CustomERC20Factory.hyp
+++ b/contracts/CustomERC20Factory.hyp
@@ -3,6 +3,12 @@ pragma hyperion ^0.0.2;
 
 import "./CustomERC20.hyp";
 
+/**
+ * @title CustomERC20Factory
+ * @notice Deploys {CustomERC20} instances. The deployed token is owned by
+ *         `msg.sender`; initial supply is minted to `recipient_` (defaults to
+ *         `msg.sender` if zero).
+ */
 contract CustomERC20Factory {
     event TokenCreated(address indexed tokenAddress, address indexed owner);
 
@@ -13,12 +19,14 @@ contract CustomERC20Factory {
         uint8 decimals_,
         uint256 maxSupply_,
         address recipient_,
-        address owner_,
         uint256 maxWalletAmount_,
         uint256 maxTxLimit_
     ) external returns (address) {
+        require(decimals_ <= 18, "CustomERC20Factory: decimals > 18");
+        require(bytes(name_).length > 0, "CustomERC20Factory: empty name");
+        require(bytes(symbol_).length > 0, "CustomERC20Factory: empty symbol");
+
         address _initialRecipient = recipient_ == address(0) ? msg.sender : recipient_;
-        address _owner = owner_ == address(0) ? msg.sender : owner_;
 
         CustomERC20 newToken = new CustomERC20(
             name_,
@@ -27,12 +35,12 @@ contract CustomERC20Factory {
             decimals_,
             maxSupply_,
             _initialRecipient,
-            _owner,
+            msg.sender,
             maxWalletAmount_,
             maxTxLimit_
         );
 
-        emit TokenCreated(address(newToken), owner_ == address(0) ? msg.sender : owner_);
+        emit TokenCreated(address(newToken), msg.sender);
         return address(newToken);
     }
 }


### PR DESCRIPTION
## Summary

Addresses the 2 High + 2 Medium findings from the Opus 4.7 security audit of the QRC20 factory contracts. Requires a factory redeploy + a coordinated `myqrlwallet-frontend` ABI / signature update (separate PR in that repo). Pre-mainnet, so clean break over backwards compat.

## Audit findings addressed

| ID  | Severity | Fix |
|-----|----------|-----|
| H-1 | High | `maxSupply` enforced — constructor requires `initialSupply_ <= maxSupply_` and `maxSupply_ > 0`; removed the silent `0 → type(uint256).max` remap; added `onlyOwner mint(to, amount)` that enforces the cap on post-deploy issuance. |
| H-2 | High | Caps and exclusion list are no longer permanently immutable — added `onlyOwner` setters `setMaxWalletAmount`, `setMaxTxLimit`, `setExcludedFromLimits` so a mis-configured token can be fixed post-deploy. Added public `isExcludedFromLimits(address)` getter and events for every state mutation. |
| M-1 | Medium | Factory no longer accepts an arbitrary `owner_` — the deployed token's owner is always `msg.sender` of the factory call. Eliminates the `OwnershipTransferred` event-trail forgery vector. The `owner_` param was removed from `createToken`. |
| M-4 | Medium | `require(decimals_ <= 18)` at both the factory entrypoint and the `CustomERC20` constructor (defense-in-depth for direct deploys). |

Plus the audit sub-finding on ownership handoff — `_transferOwnership` is overridden to move the cap-bypass exemption from the old owner to the new owner, keeping the "owner bypasses caps" invariant consistent. Also added empty-name / empty-symbol / zero-address rejections at construction.

## Breaking changes

- **Factory `createToken` signature changed from 9 params to 8** (dropped `owner_`). ABI hash changes. `myqrlwallet-frontend` needs a coordinated update:
  - Regenerate `src/abi/CustomERC20FactoryABI.ts` from the new compiled output.
  - Drop the `owner` arg from `qrlStore.createToken()` and the UI form.
  - Update `VITE_CUSTOMERC20FACTORY_ADDRESS` after a fresh factory is deployed against the merged `main`.
- **`CustomERC20` constructor tightened** — `maxSupply = 0` now reverts, `initialSupply > maxSupply` reverts, `decimals > 18` reverts, zero recipient/owner reverts. UIs that previously let users leave `maxSupply` blank (defaulting to 0 → unlimited) must now default to a meaningful value or require an explicit entry.

## Validation (live against QRL v2 testnet, chain 1337)

Test factory deployed at `Q7c34495855883f38041217760dbb06a66a63cc4b`, tx `0x505b9645f7f495775bc1cfba5f49d6728d09dcbf259ed0c3a2cd40460370631d`, block 30882, from `Q79b662Ce3d663643dF4454A8Ba3f532C0DE6887f`.

### Happy path
- [x] `createToken(...)` → new token `Q0c2f1f560cfa8a59af0c27a8190d89cfd7f75aa3`
- [x] `owner()` == `msg.sender` (confirms M-1)
- [x] `isExcludedFromLimits(factory)` == `false` (confirms handoff override removed the factory's exemption)
- [x] `isExcludedFromLimits(owner)` == `true` (confirms override added the new owner)
- [x] `name`, `symbol`, `decimals`, `totalSupply`, `maxSupply`, `maxWalletAmount`, `maxTxLimit` all read-back correctly

### Revert paths (via `eth_call`)
- [x] `decimals=19` → reverts `CustomERC20Factory: decimals > 18`
- [x] `initialSupply > maxSupply` → reverts `CustomERC20: initialSupply exceeds maxSupply`
- [x] `maxSupply=0` → reverts `CustomERC20: maxSupply is zero`
- [x] empty `name` → reverts `CustomERC20Factory: empty name`
- [x] `mint` beyond cap → reverts `CustomERC20: exceeds maxSupply`
- [x] `setMaxWalletAmount` from non-owner → reverts `Ownable: caller is not the owner`
- [x] `mint` from non-owner → reverts `Ownable: caller is not the owner`

### Owner setters (live txs, status 1)
- [x] `setMaxWalletAmount(777)` — state updated from 1e23 → 777
- [x] `setMaxTxLimit(888)` — state updated from 1e23 → 888
- [x] `setExcludedFromLimits(random, true)` — mapping updated, event emitted

## Test plan (reviewer-executable)

- [ ] `npm ci && node contract-compiler.js` produces clean compile (no errors)
- [ ] `node 1-deploy.js` against a v2 testnet RPC deploys without error and returns a Q-prefixed contract address
- [ ] `node 2-onchain-call.js` against the new factory (updated `CUSTOM_ERC20_FACTORY_ADDRESS`) produces a fresh token with the expected state
- [ ] `node 3-offchain-call.js` on the token prints name/symbol/decimals/totalSupply/balance correctly

## Does not block

Findings **not** addressed in this PR (separate work, intentionally scoped out):
- M-2 (factory is permissionless, no rate-limit) — kept as-is; on-chain gas is the only spam brake by design.
- M-3 (no burn function) — can add in a follow-up if desired.
- L-1..L-7 — low-severity / informational items from the audit.

## Migration notes

Once merged → deploy to main → new factory address captured → frontend PR:
- Updates `VITE_CUSTOMERC20FACTORY_ADDRESS` on `ops@49.13.162.117` prod + dev
- Regenerates the frontend ABI
- Drops `owner` from the UI form
- Rebuilds + `sudo cp` to nginx webroots

V1-factory tokens (`Qa9243…`) remain on the chain under the old cap-immutable / owner-forgeable semantics — they were minted before this PR and cannot be migrated. A user-facing notice on new-token creation describing "you can change caps post-deploy" is worth adding in the frontend PR.