### PR TITLE
Promote dev → main: contract hardening (H-1, H-2, M-1, M-4)

### DIFF
--- a/2-onchain-call.js
+++ b/2-onchain-call.js
@@ -49,7 +49,6 @@ const initialSupply = "1000000000000000000000000000"
 const decimals = 18
 const maxSupply = "1000000000000000000000000000"
 const recipient = "Q0000000000000000000000000000000000000000"
-const owner = "Q0000000000000000000000000000000000000000"
 const maxWalletAmount = "100000000000000000000000"
 const maxTxLimit = "100000000000000000000000"
 
@@ -62,7 +61,7 @@ const createCustomQRC20Token = async () => {
 
     const contract = new web3.qrl.Contract(contractABI, contractAddress)
 
-    const createTokenMethod = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, owner, maxWalletAmount, maxTxLimit);
+    const createTokenMethod = contract.methods.createToken(tokenName, tokenSymbol, initialSupply, decimals, maxSupply, recipient, maxWalletAmount, maxTxLimit);
     const estimatedGas = await createTokenMethod.estimateGas({ from: acc.address })
     const gas = (estimatedGas * 12n) / 10n
     const gasPrice = await web3.qrl.getGasPrice()

--- a/contracts/CustomERC20.hyp
+++ b/contracts/CustomERC20.hyp
@@ -62,10 +62,12 @@ contract CustomERC20 is ERC20, Ownable {
 
     /**
      * @notice Mint `amount` new tokens to `to`. Only callable by the owner.
-     *         Reverts if `totalSupply() + amount > maxSupply`.
+     *         Reverts if `totalSupply() + amount > maxSupply`. Uses
+     *         subtraction form to guarantee the revert message fires
+     *         regardless of how the compiler handles arithmetic overflow.
      */
     function mint(address to, uint256 amount) external onlyOwner {
-        require(totalSupply() + amount <= maxSupply, "CustomERC20: exceeds maxSupply");
+        require(amount <= maxSupply - totalSupply(), "CustomERC20: exceeds maxSupply");
         _mint(to, amount);
     }
 

--- a/contracts/CustomERC20.hyp
+++ b/contracts/CustomERC20.hyp
@@ -4,6 +4,12 @@ pragma hyperion ^0.0.2;
 import "./ERC20.hyp";
 import "./Ownable.hyp";
 
+/**
+ * @title CustomERC20
+ * @notice QRC20 token with configurable supply cap, per-wallet cap, and per-tx cap.
+ *         The owner can mint up to `maxSupply`, adjust caps, and manage the
+ *         cap-bypass whitelist post-deploy. `maxSupply` is immutable.
+ */
 contract CustomERC20 is ERC20, Ownable {
     uint8 private immutable _decimals;
     uint256 public immutable maxSupply;
@@ -11,6 +17,10 @@ contract CustomERC20 is ERC20, Ownable {
     uint256 public maxTxLimit;
 
     mapping(address => bool) private _isExcludedFromLimits;
+
+    event MaxWalletAmountUpdated(uint256 previousValue, uint256 newValue);
+    event MaxTxLimitUpdated(uint256 previousValue, uint256 newValue);
+    event ExcludedFromLimitsUpdated(address indexed account, bool excluded);
 
     constructor(
         string memory name_,
@@ -23,21 +33,91 @@ contract CustomERC20 is ERC20, Ownable {
         uint256 maxWalletAmount_,
         uint256 maxTxLimit_
     ) ERC20(name_, symbol_) Ownable() {
+        require(decimals_ <= 18, "CustomERC20: decimals > 18");
+        require(maxSupply_ > 0, "CustomERC20: maxSupply is zero");
+        require(initialSupply_ <= maxSupply_, "CustomERC20: initialSupply exceeds maxSupply");
+        require(owner_ != address(0), "CustomERC20: owner is zero");
+        require(recipient_ != address(0), "CustomERC20: recipient is zero");
+
         _decimals = decimals_;
-        maxSupply = maxSupply_ > 0 ? maxSupply_ : type(uint256).max; // Default to unlimited if not set
+        maxSupply = maxSupply_;
         maxWalletAmount = maxWalletAmount_;
         maxTxLimit = maxTxLimit_;
 
         _mint(recipient_, initialSupply_);
 
         _isExcludedFromLimits[recipient_] = true;
-        _isExcludedFromLimits[owner_] = true;
+        emit ExcludedFromLimitsUpdated(recipient_, true);
 
+        // transferOwnership will move exclusion from the deploying contract
+        // (factory / EOA) to owner_ via the _transferOwnership override.
         transferOwnership(owner_);
     }
 
     function decimals() public view override returns (uint8) {
         return _decimals;
+    }
+
+    /**
+     * @notice Mint `amount` new tokens to `to`. Only callable by the owner.
+     *         Reverts if `totalSupply() + amount > maxSupply`.
+     */
+    function mint(address to, uint256 amount) external onlyOwner {
+        require(totalSupply() + amount <= maxSupply, "CustomERC20: exceeds maxSupply");
+        _mint(to, amount);
+    }
+
+    /**
+     * @notice Set the per-wallet holding cap. Zero disables the cap.
+     */
+    function setMaxWalletAmount(uint256 newValue) external onlyOwner {
+        emit MaxWalletAmountUpdated(maxWalletAmount, newValue);
+        maxWalletAmount = newValue;
+    }
+
+    /**
+     * @notice Set the per-tx transfer cap. Zero disables the cap.
+     */
+    function setMaxTxLimit(uint256 newValue) external onlyOwner {
+        emit MaxTxLimitUpdated(maxTxLimit, newValue);
+        maxTxLimit = newValue;
+    }
+
+    /**
+     * @notice Add or remove `account` from the cap-bypass whitelist.
+     *         Whitelisted accounts bypass both maxWalletAmount and maxTxLimit
+     *         on both the sender and recipient side.
+     */
+    function setExcludedFromLimits(address account, bool excluded) external onlyOwner {
+        _isExcludedFromLimits[account] = excluded;
+        emit ExcludedFromLimitsUpdated(account, excluded);
+    }
+
+    /**
+     * @notice Returns true if `account` is exempt from per-wallet / per-tx caps.
+     */
+    function isExcludedFromLimits(address account) external view returns (bool) {
+        return _isExcludedFromLimits[account];
+    }
+
+    /**
+     * @dev Keeps the cap-bypass whitelist aligned with the owner role across
+     *      ownership handoffs. Renouncing ownership (newOwner == address(0))
+     *      still revokes the old owner's exemption; a follow-up
+     *      setExcludedFromLimits(oldOwner, true) by the new owner can restore
+     *      it if desired.
+     */
+    function _transferOwnership(address newOwner) internal override {
+        address oldOwner = owner();
+        if (oldOwner != address(0) && oldOwner != newOwner) {
+            _isExcludedFromLimits[oldOwner] = false;
+            emit ExcludedFromLimitsUpdated(oldOwner, false);
+        }
+        if (newOwner != address(0) && !_isExcludedFromLimits[newOwner]) {
+            _isExcludedFromLimits[newOwner] = true;
+            emit ExcludedFromLimitsUpdated(newOwner, true);
+        }
+        super._transferOwnership(newOwner);
     }
 
     function transfer(address recipient, uint256 amount) public override returns (bool) {

--- a/contracts/CustomERC20.hyp
+++ b/contracts/CustomERC20.hyp
@@ -33,6 +33,8 @@ contract CustomERC20 is ERC20, Ownable {
         uint256 maxWalletAmount_,
         uint256 maxTxLimit_
     ) ERC20(name_, symbol_) Ownable() {
+        require(bytes(name_).length > 0, "CustomERC20: empty name");
+        require(bytes(symbol_).length > 0, "CustomERC20: empty symbol");
         require(decimals_ <= 18, "CustomERC20: decimals > 18");
         require(maxSupply_ > 0, "CustomERC20: maxSupply is zero");
         require(initialSupply_ <= maxSupply_, "CustomERC20: initialSupply exceeds maxSupply");

--- a/contracts/CustomERC20Factory.hyp
+++ b/contracts/CustomERC20Factory.hyp
@@ -3,6 +3,12 @@ pragma hyperion ^0.0.2;
 
 import "./CustomERC20.hyp";
 
+/**
+ * @title CustomERC20Factory
+ * @notice Deploys {CustomERC20} instances. The deployed token is owned by
+ *         `msg.sender`; initial supply is minted to `recipient_` (defaults to
+ *         `msg.sender` if zero).
+ */
 contract CustomERC20Factory {
     event TokenCreated(address indexed tokenAddress, address indexed owner);
 
@@ -13,12 +19,14 @@ contract CustomERC20Factory {
         uint8 decimals_,
         uint256 maxSupply_,
         address recipient_,
-        address owner_,
         uint256 maxWalletAmount_,
         uint256 maxTxLimit_
     ) external returns (address) {
+        require(decimals_ <= 18, "CustomERC20Factory: decimals > 18");
+        require(bytes(name_).length > 0, "CustomERC20Factory: empty name");
+        require(bytes(symbol_).length > 0, "CustomERC20Factory: empty symbol");
+
         address _initialRecipient = recipient_ == address(0) ? msg.sender : recipient_;
-        address _owner = owner_ == address(0) ? msg.sender : owner_;
 
         CustomERC20 newToken = new CustomERC20(
             name_,
@@ -27,12 +35,12 @@ contract CustomERC20Factory {
             decimals_,
             maxSupply_,
             _initialRecipient,
-            _owner,
+            msg.sender,
             maxWalletAmount_,
             maxTxLimit_
         );
 
-        emit TokenCreated(address(newToken), owner_ == address(0) ? msg.sender : owner_);
+        emit TokenCreated(address(newToken), msg.sender);
         return address(newToken);
     }
 }


### PR DESCRIPTION
## Summary

Promotes the hardened factory from `dev` to `main`. The three commits originate from PR #6 (contract hardening per Opus 4.7 security audit) which was already validated end-to-end on QRL v2 testnet and is currently live on `dev.qrlwallet.com`.

| OID | Commit |
|-----|--------|
| `2c7754e` | feat: harden factory contracts per security audit (H-1, H-2, M-1, M-4) |
| `d7a1e78` | chore: defense-in-depth empty name/symbol check in CustomERC20 constructor (gemini review fix) |
| `067cef6` | Merge pull request #6 from DigitalGuards/feat/contract-hardening |

## Audit findings addressed

| ID | Severity | Fix |
|---|---|---|
| H-1 | High | `maxSupply` meaningfully enforced: constructor requires `maxSupply > 0` and `initialSupply <= maxSupply`. `onlyOwner mint()` added and enforces `totalSupply + amount <= maxSupply`. Silent `0 → type(uint256).max` remap removed. |
| H-2 | High | `onlyOwner` setters added for `maxWalletAmount`, `maxTxLimit`, and `_isExcludedFromLimits` plus a public `isExcludedFromLimits()` getter. Mis-configured tokens are no longer permanently bricked. |
| M-1 | Medium | Factory `createToken` dropped `owner_` parameter; the deployed token's owner is always `msg.sender`. Removes the event-trail forgery vector. |
| M-4 | Medium | `require(decimals <= 18)` at both the factory entrypoint and the `CustomERC20` constructor. |
| Sub | Info | `_transferOwnership` override moves the cap-bypass exemption from old → new owner, keeping the "owner bypasses caps" invariant consistent across handoffs. |
| Gemini | Medium | Defense-in-depth `require(bytes(name_).length > 0)` / `require(bytes(symbol_).length > 0)` / `require(owner_ != address(0))` / `require(recipient_ != address(0))` in the `CustomERC20` constructor for direct deploys that bypass the factory. |

## Validation

Already live on QRL v2 testnet, already validated end-to-end:
- Hardened factory deployed at `Q1b7cff4399f7e3a96f5321d72fe050401de97e5a` (chain 1337).
- Frontend serving hardened ABI on `dev.qrlwallet.com` (bundle `index-BoPVOwIx.js`).
- End-user token creation flow confirmed: `Q82645bdba4fc2efd71bfefa3924594c7ef25d852` (TKF / "Hardened Token Factory", 3 decimals) minted at block 30961, tx `0xfdc45c41ec52492c15f8f18bd109861dbb653c38bb90f7b84febfbe451b53b9c`, gas 4.72M.
- All revert paths verified via `eth_call` (decimals > 18, initialSupply > maxSupply, maxSupply = 0, empty name, non-owner setters, mint beyond cap).

Coordinated with frontend promotion: [DigitalGuards/myqrlwallet-frontend#123](https://github.com/DigitalGuards/myqrlwallet-frontend/pull/123) (TBD PR number — will cross-link once opened).

## Test plan

- [ ] `main` HEAD moves to `067cef6`
- [ ] `npm ci && node 1-deploy.js` against a v2 testnet RPC deploys cleanly from fresh clone of main
- [ ] Factory ABI returned matches expectations (8-arg `createToken`, `TokenCreated(indexed address, indexed address)`)