### PR TITLE
chore: rename package to qrc20-factory (repo renamed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "qrlv2-qrc20-factory",
+  "name": "qrc20-factory",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "qrlv2-qrc20-factory",
+      "name": "qrc20-factory",
       "version": "0.2.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "qrlv2-qrc20-factory",
+  "name": "qrc20-factory",
   "version": "0.2.0",
   "description": "Custom QRC20 token factory for the QRL v2 (post-quantum) chain",
   "main": "1-deploy.js",


### PR DESCRIPTION
Matches the repository rename `DigitalGuards/QRLv2-QRC20-Factory → DigitalGuards/QRC20-Factory`. 'QRLv2' was a transitional label when the post-quantum chain was still distinguished from Zond; now that v2 is the canonical QRL chain, the prefix is redundant.

- `package.json` name field → `qrc20-factory`
- `package-lock.json` regenerated against the renamed package field

No code changes; no ABI changes.