### PR TITLE
Promote dev → main: rename package to qrc20-factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "qrlv2-qrc20-factory",
+  "name": "qrc20-factory",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "qrlv2-qrc20-factory",
+      "name": "qrc20-factory",
       "version": "0.2.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "qrlv2-qrc20-factory",
+  "name": "qrc20-factory",
   "version": "0.2.0",
   "description": "Custom QRC20 token factory for the QRL v2 (post-quantum) chain",
   "main": "1-deploy.js",


### PR DESCRIPTION
Brings the package-name rename (part of repo rename `QRLv2-QRC20-Factory → QRC20-Factory`) into `main`. Single commit — no code changes, no ABI changes.